### PR TITLE
DOC: Missing break statement in example provided in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ if (res.tag === PARSE_FAILURE) { // Alternatively, `if (res.error) {`
   switch (operator) {
     case "add":
       console.log(a + b);
+      break;
     case "sub":
       console.log(a - b);
+      break;
   }
 }
 ```

--- a/lib/README.md
+++ b/lib/README.md
@@ -78,8 +78,10 @@ if (res.tag === PARSE_FAILURE) { // Alternatively, `if (res.error) {`
   switch (operator) {
     case "add":
       console.log(a + b);
+      break;
     case "sub":
       console.log(a - b);
+      break;
   }
 }
 ```


### PR DESCRIPTION
Found that the output of the sample program is not as expected since there is a missing `break` statement in the example provided.